### PR TITLE
Disable equipping items and looting chests while in an active adventu…

### DIFF
--- a/adventure/adventure.py
+++ b/adventure/adventure.py
@@ -414,7 +414,7 @@ class Adventure(BaseCog):
             price=total_price,
             items=msg,
         )
-        for page in pagify(new_msg):
+        for page in pagify(new_msg, shorten_by=10):
             msg_list.append(box(page, lang="css"))
         await menu(ctx, msg_list, DEFAULT_CONTROLS)
 
@@ -459,7 +459,10 @@ class Adventure(BaseCog):
             except Exception:
                 log.exception("Error with the new character sheet")
                 return
-            item = c.backpack[item.name]
+            try:
+                item = c.backpack[item.name]
+            except KeyError:
+                return
             msg = ""
             if pred.result == 0:  # user reacted with one to sell.
                 # sell one of the item
@@ -2725,6 +2728,9 @@ class Adventure(BaseCog):
                         msg = _(
                             "{author} removed the {current_item} and put it into their backpack."
                         ).format(author=self.E(ctx.author.display_name), current_item=current_item)
+                        # We break if this works because unequip 
+                        # will autmatically remove multiple items
+                        break
             if msg:
                 await ctx.send(box(msg, lang="css"))
                 await self.config.user(ctx.author).set(c._to_json())
@@ -2755,7 +2761,10 @@ class Adventure(BaseCog):
                 await self._clear_react(msg)
                 return
             if pred.result:
-                del self._sessions[ctx.guild.id]
+                try:
+                    del self._sessions[ctx.guild.id]
+                except KeyError:
+                    pass
             else:
                 return
         if challenge and not await ctx.bot.is_owner(ctx.author):

--- a/adventure/adventure.py
+++ b/adventure/adventure.py
@@ -1292,7 +1292,7 @@ class Adventure(BaseCog):
                     return await ctx.send(timeout_msg)
                 new_ctx = await self.bot.get_context(reply)
                 item = await ItemConverter().convert(new_ctx, reply.content)
-                if item.rarity == "forgeable":
+                if item.rarity == "forged":
                     ctx.command.reset_cooldown(ctx)
                     return await ctx.send(
                         _("{}, tinkered devices cannot be reforged.").format(
@@ -1324,7 +1324,7 @@ class Adventure(BaseCog):
                     return await ctx.send(timeout_msg)
                 new_ctx = await self.bot.get_context(reply)
                 item = await ItemConverter().convert(new_ctx, reply.content)
-                if item.rarity == "forgeable":
+                if item.rarity == "forged":
                     ctx.command.reset_cooldown(ctx)
                     return await ctx.send(
                         _("{}, tinkered devices cannot be reforged.").format(
@@ -2731,7 +2731,7 @@ class Adventure(BaseCog):
                         msg = _(
                             "{author} removed the {current_item} and put it into their backpack."
                         ).format(author=self.E(ctx.author.display_name), current_item=current_item)
-                        # We break if this works because unequip 
+                        # We break if this works because unequip
                         # will autmatically remove multiple items
                         break
             if msg:
@@ -2883,7 +2883,7 @@ class Adventure(BaseCog):
             attr=session.attribute, chall=session.challenge, threat=random.choice(self.THREATEE)
         )
 
-        
+
         embed = discord.Embed(colour=discord.Colour.blurple())
         use_embeds = (
             await self.config.guild(ctx.guild).embed()

--- a/adventure/charsheet.py
+++ b/adventure/charsheet.py
@@ -57,11 +57,11 @@ class Stats(Converter):
     to create an item object to be added to a users inventory
     """
 
-    ATT = re.compile(r"([\d]*) (att(?:ack)?)")
-    CHA = re.compile(r"([\d]*) (cha(?:risma)?|dip(?:lo?(?:macy)?)?)")
-    INT = re.compile(r"([\d]*) (int(?:elligence)?)")
-    LUCK = re.compile(r"([\d]*) (luck)")
-    DEX = re.compile(r"([\d]*) (dex(?:terity)?)")
+    ATT = re.compile(r"([\-\d]*) (att(?:ack)?)")
+    CHA = re.compile(r"([\-\d]*) (cha(?:risma)?|dip(?:lo?(?:macy)?)?)")
+    INT = re.compile(r"([\-\d]*) (int(?:elligence)?)")
+    LUCK = re.compile(r"([\-\d]*) (luck)")
+    DEX = re.compile(r"([\-\d]*) (dex(?:terity)?)")
     SLOT = re.compile(r"(head|neck|chest|gloves|belt|legs|boots|left|right|ring|charm|twohanded)")
     RARITY = re.compile(r"(normal|rare|epic|legend(?:ary)?)")
 
@@ -227,12 +227,13 @@ class ItemConverter(Converter):
             return lookup_m[0]
         elif len(lookup) == 0 and len(lookup_m) == 0:
             raise BadArgument(
-                _("`{}` doesn't seem to match any items you own.").format(argument)
+                _("`{}` doesn't seem to match any items in your backpack.").format(argument)
             )
         else:
             if len(lookup) > 10:
                 raise BadArgument(
-                    _("You have too matching the name `{}`, please be more specific").format(
+                    _("You have too many items matching the name `{}`,"
+                      " please be more specific").format(
                         argument
                     )
                 )


### PR DESCRIPTION
…re. This should alleviate issue #54 and #55

enable clearing of active adventures inside a server - This *should* never be required although in practice it occurs every so often requiring the cog to be reloaded. (This should alleviate #60)

Add ability to clear character sheets and remove items from users. Solves #58

Found better solution for #52 and solve #57.

Allow items to be given with negative stats. Solves #56