### PR TITLE
Use smart apostrophes when displaying forged items

### DIFF
--- a/adventure/charsheet.py
+++ b/adventure/charsheet.py
@@ -139,7 +139,8 @@ class Item:
         if self.rarity == "legendary":
             return f"{LEGENDARY_OPEN}{self.name}{LEGENDARY_CLOSE}"
         if self.rarity == "forged":
-            return f"{TINKER_OPEN}{self.name}{TINKER_CLOSE}"
+            name = self.name.replace("'", "’")
+            return f"{TINKER_OPEN}{name}{TINKER_CLOSE}"
             # Thanks Sinbad!
 
     @staticmethod


### PR DESCRIPTION
This prevents formatting errors ([like this one](https://cdn.discordapp.com/attachments/492050319241379871/640041394949586944/unknown.png)) from forged items.