### PR TITLE
Fix fight/melee crit calculation.

### DIFF
--- a/adventure/adventure.py
+++ b/adventure/adventure.py
@@ -3639,7 +3639,7 @@ class Adventure(commands.Cog):
             except Exception:
                 log.exception("Error with the new character sheet")
                 continue
-            crit_mod = max(c.dex, c.luck) // 10
+            crit_mod = max(c.dex, c.luck)
             mod = 0
             if crit_mod != 0:
                 mod = round(crit_mod / 10)


### PR DESCRIPTION
Fight/melee crit_mod calculation was dividing by 10 twice, while other actions only did so once. This meant over 60 luck/dex was needed to have any impact on the calculation.