### PR TITLE
Add max roll to ‘[p]stats’ command

### DIFF
--- a/adventure/adventure.py
+++ b/adventure/adventure.py
@@ -6660,7 +6660,7 @@ class Adventure(commands.Cog):
                 continue
             crit_mod = max(max(c.dex, c.luck // 2) + (c.total_att // 20), 0)  # Thanks GoaFan77
             mod = 0
-            max_roll = 100 if c.rebirths >= 30 else 50 if c.rebirths >= 15 else 20
+            max_roll = c.maxroll
             if crit_mod != 0:
                 mod = round(crit_mod / 10)
             if c.rebirths < 15 < mod:

--- a/adventure/charsheet.py
+++ b/adventure/charsheet.py
@@ -192,8 +192,8 @@ class Item:
             self.total_stats *= 2
         self.max_main_stat = max(self.att, self.int, self.cha, 1)
         self.lvl: int = (
-            kwargs.get("lvl") or self.get_equip_level()
-        ) if self.rarity == "event" else self.get_equip_level()
+            (kwargs.get("lvl") or self.get_equip_level()) if self.rarity == "event" else self.get_equip_level()
+        )
         self.degrade = kwargs.get("degrade", 5)
 
     def __str__(self):
@@ -689,13 +689,13 @@ class Character(Item):
         statmult = self.gear_set_bonus.get("statmult") - 1
         xpmult = (self.gear_set_bonus.get("xpmult") + daymult) - 1
         cpmult = (self.gear_set_bonus.get("cpmult") + daymult) - 1
-        next_max_roll_level=self.get_max_roll_next_level()
-        next_max_roll_level_text = "";
+        next_max_roll_level = self.get_max_roll_next_level()
+        next_max_roll_level_text = ""
 
         if next_max_roll_level == 1:
-            next_max_roll_level_text = _("(next level in 1 rebirth)");
+            next_max_roll_level_text = _("(next level in 1 rebirth)")
         elif next_max_roll_level > 1:
-            next_max_roll_level_text = f"(next level in {next_max_roll_level} rebirths)";        
+            next_max_roll_level_text = f"(next level in {next_max_roll_level} rebirths)"
 
         return _(
             "{user}'s Character Sheet\n\n"
@@ -812,22 +812,22 @@ class Character(Item):
         return form_string + "\n"
 
     def get_max_roll(self) -> int:
-        max_roll = 20;
+        max_roll = 20
 
         if self.rebirths >= 30:
-            max_roll = 100;
+            max_roll = 100
         elif self.rebirths >= 15:
-            max_roll = 50;
+            max_roll = 50
 
-        return max_roll;
+        return max_roll
 
     def get_max_roll_next_level(self) -> int:
         if self.rebirths >= 30:
-            return False;
+            return False
         elif self.rebirths >= 15:
-            return 30 - self.rebirths;
+            return 30 - self.rebirths
 
-        return 15 - self.rebirths;
+        return 15 - self.rebirths
 
     def get_max_level(self) -> int:
         rebirths = max(self.rebirths, 0)

--- a/adventure/charsheet.py
+++ b/adventure/charsheet.py
@@ -486,6 +486,7 @@ class Character(Item):
         self.gear_set_bonus = {}
         self.get_set_bonus()
         self.maxlevel = self.get_max_level()
+        self.maxroll = self.get_max_roll()
         self.lvl = self.lvl if self.lvl < self.maxlevel else self.maxlevel
         self.set_items = self.get_set_item_count()
         self.att, self._att = self.get_stat_value("att")
@@ -688,9 +689,17 @@ class Character(Item):
         statmult = self.gear_set_bonus.get("statmult") - 1
         xpmult = (self.gear_set_bonus.get("xpmult") + daymult) - 1
         cpmult = (self.gear_set_bonus.get("cpmult") + daymult) - 1
+        next_max_roll_level=self.get_max_roll_next_level()
+        next_max_roll_level_text = "";
+
+        if next_max_roll_level == 1:
+            next_max_roll_level_text = _("(next level in 1 rebirth)");
+        elif next_max_roll_level > 1:
+            next_max_roll_level_text = f"(next level in {next_max_roll_level} rebirths)";        
+
         return _(
             "{user}'s Character Sheet\n\n"
-            "{{Rebirths: {rebirths}, \n Max Level: {maxlevel}}}\n"
+            "--- \nRebirths: {rebirths}\nMax level: {maxlevel}\nMax roll: {max_roll} {next_max_roll_level_text}\n---\n"
             "{rebirth_text}"
             "A level {lvl} {class_desc} \n\n- "
             "ATTACK: {att} [+{att_skill}] - "
@@ -712,6 +721,9 @@ class Character(Item):
             if self.lvl < self.maxlevel
             else _("You have reached max level. To continue gaining levels and xp, you will have to rebirth.\n\n"),
             maxlevel=self.maxlevel,
+            max_roll=self.maxroll,
+            next_max_roll_level_text=next_max_roll_level_text,
+            next_roll_level_text="",
             class_desc=class_desc,
             att=humanize_number(self.att),
             att_skill=humanize_number(self.skill["att"]),
@@ -798,6 +810,24 @@ class Character(Item):
             )
 
         return form_string + "\n"
+
+    def get_max_roll(self) -> int:
+        max_roll = 20;
+
+        if self.rebirths >= 30:
+            max_roll = 100;
+        elif self.rebirths >= 15:
+            max_roll = 50;
+
+        return max_roll;
+
+    def get_max_roll_next_level(self) -> int:
+        if self.rebirths >= 30:
+            return False;
+        elif self.rebirths >= 15:
+            return 30 - self.rebirths;
+
+        return 15 - self.rebirths;
 
     def get_max_level(self) -> int:
         rebirths = max(self.rebirths, 0)


### PR DESCRIPTION
Thought I would try and help out with some of the development of this, rather than just requesting features 😅 Note I only tested this on my empty server. The public server I am on with this bot on uses your untouched code and always will.

Feel free to tweak messaging as you see fit. Summary of changes:

- Tweaked the formatting of this information as it looked inconsistent (added ---)
- Refactored max_roll into a function and use this from `adventure.py`
- Added "Max roll: X"
- Show the message "(next level in X rebirths)" if the user has several rebirths to go
- Show the message "(next level in 1 rebirth)" if the user only has 1 rebirth to go
- Don't show the message if the user is at max level for the dice

I've attached a screenshot of the updates stats window here:
https://imgur.com/N6aUZ3t

https://github.com/aikaterna/gobcog/issues/323