### PR TITLE
Use a relative timestamp instead of editing the message every 5 seconds.

### DIFF
--- a/adventure/adventure.py
+++ b/adventure/adventure.py
@@ -2353,7 +2353,8 @@ class Adventure(
             secondint = int(seconds)
             adv_end = await _get_epoch(secondint)
             timer, done, sremain = await _remaining(adv_end)
-            message_adv = await ctx.send(f"⏳ [{title}] {timer}s")
+            timer = f"<t:{int(adv_end)}:R>"
+            message_adv = await ctx.send(f"⏳ [{title}] {timer}")
             deleted = False
             while not done:
                 timer, done, sremain = await _remaining(adv_end)
@@ -2362,11 +2363,6 @@ class Adventure(
                     if not deleted:
                         await message_adv.delete()
                     break
-                elif not deleted and int(sremain) % 5 == 0:
-                    try:
-                        await message_adv.edit(content=f"⏳ [{title}] {timer}s")
-                    except discord.NotFound:
-                        deleted = True
                 await asyncio.sleep(1)
             log.debug("Timer countdown done.")
 

--- a/adventure/bank/bank.py
+++ b/adventure/bank/bank.py
@@ -50,7 +50,7 @@ __all__ = [
     "BankPruneError",
 ]
 
-_MAX_BALANCE = 2 ** 63 - 1
+_MAX_BALANCE = 2**63 - 1
 
 _DEFAULT_MEMBER = {"balance": 0, "next_payday": 0}
 


### PR DESCRIPTION
In the future we may put this on the embed message instead but for now we'll keep it the same as before.