### PR TITLE
Fix typo in "adventures"

### DIFF
--- a/adventure/adventure.py
+++ b/adventure/adventure.py
@@ -1230,7 +1230,7 @@ class Adventure(
                 run_msg = _("It's a shame for the following adventurers...\n{run_msg}\n").format(run_msg=run_msg)
 
             output = _(
-                "All adventures prepared for an epic adventure, but they soon realise all this treasure was unprotected!\n{run_msg}{text}"
+                "All adventurers prepared for an epic adventure, but they soon realise all this treasure was unprotected!\n{run_msg}{text}"
             ).format(
                 text=text,
                 run_msg=run_msg,


### PR DESCRIPTION
In [adventure.py](https://github.com/chawkk6404/gobcog/blob/master/adventure/adventure.py#L1233), when there is no mob in a hard mode adventure, the message sent has a typo. The word "adventures" was changed to "adventurers".