### PR TITLE
some fixes

### DIFF
--- a/adventure/adventure.py
+++ b/adventure/adventure.py
@@ -837,12 +837,11 @@ class Adventure(
             attribute = attribute.lower()
         else:
             attribute = random.choice(list(self.ATTRIBS.keys()))
-        if transcended:
-            new_challenge = challenge.replace("Ascended", "Transcended")
-        else:
-            new_challenge = challenge
-
+        new_challenge = challenge
         if easy_mode:
+            if transcended:
+                # Shows Transcended on Easy mode
+                new_challenge = _("Transcended {}").format(challenge.replace("Ascended", ""))
             no_monster = False
             if monster_roster[challenge]["boss"]:
                 timer = 60 * 5
@@ -853,7 +852,7 @@ class Adventure(
                 self.bot.dispatch("adventure_miniboss", ctx)
             else:
                 timer = 60 * 2
-            if "Transcended" in new_challenge:
+            if transcended:
                 self.bot.dispatch("adventure_transcended", ctx)
             elif "Ascended" in new_challenge:
                 self.bot.dispatch("adventure_ascended", ctx)
@@ -862,6 +861,9 @@ class Adventure(
             elif attribute == " possessed":
                 self.bot.dispatch("adventure_possessed", ctx)
         else:
+            if transcended:
+                # Hide Transcended on Easy mode
+                new_challenge = challenge.replace("Ascended", "")
             timer = 60 * 3
             no_monster = random.randint(0, 100) == 25
         self._sessions[ctx.guild.id] = GameSession(
@@ -1320,7 +1322,7 @@ class Adventure(
                 roll = random.randint(1, 10)
                 monster_amount = hp + dipl if slain and persuaded else hp if slain else dipl
                 if session.transcended:
-                    if session.boss and "Trancended" in session.challenge:
+                    if session.boss and not session.no_monster:
                         avaliable_loot = [
                             [0, 0, 1, 5, 2, 1],
                             [0, 0, 0, 0, 1, 1],
@@ -1372,7 +1374,7 @@ class Adventure(
                 roll = random.randint(1, 10)
                 monster_amount = hp + dipl if slain and persuaded else hp if slain else dipl
                 if session.transcended:
-                    if session.boss and "Trancended" in session.challenge:
+                    if session.boss and not session.no_monster:
                         avaliable_loot = [
                             [0, 0, 1, 5, 4, 2],
                             [0, 0, 3, 4, 5, 2],

--- a/adventure/adventure.py
+++ b/adventure/adventure.py
@@ -1257,8 +1257,8 @@ class Adventure(
         )
         result_msg = run_msg + pray_msg + talk_msg + fight_msg
         challenge_attrib = session.attribute
-        hp = int(session.monster_modified_stats["hp"] * self.ATTRIBS[challenge_attrib][0] * session.monster_stats)
-        dipl = int(session.monster_modified_stats["dipl"] * self.ATTRIBS[challenge_attrib][1] * session.monster_stats)
+        hp =max(int(session.monster_modified_stats["hp"] * self.ATTRIBS[challenge_attrib][0] * session.monster_stats), 1)
+        dipl = max(int(session.monster_modified_stats["dipl"] * self.ATTRIBS[challenge_attrib][1] * session.monster_stats), 1)
 
         dmg_dealt = int(attack + magic)
         diplomacy = int(diplomacy)

--- a/adventure/adventure.py
+++ b/adventure/adventure.py
@@ -1257,8 +1257,12 @@ class Adventure(
         )
         result_msg = run_msg + pray_msg + talk_msg + fight_msg
         challenge_attrib = session.attribute
-        hp =max(int(session.monster_modified_stats["hp"] * self.ATTRIBS[challenge_attrib][0] * session.monster_stats), 1)
-        dipl = max(int(session.monster_modified_stats["dipl"] * self.ATTRIBS[challenge_attrib][1] * session.monster_stats), 1)
+        hp = max(
+            int(session.monster_modified_stats["hp"] * self.ATTRIBS[challenge_attrib][0] * session.monster_stats), 1
+        )
+        dipl = max(
+            int(session.monster_modified_stats["dipl"] * self.ATTRIBS[challenge_attrib][1] * session.monster_stats), 1
+        )
 
         dmg_dealt = int(attack + magic)
         diplomacy = int(diplomacy)

--- a/adventure/adventure.py
+++ b/adventure/adventure.py
@@ -93,7 +93,7 @@ class Adventure(
             user_id
         ).clear()  # This will only ever touch the separate currency, leaving bot economy to be handled by core.
 
-    __version__ = "3.5.3"
+    __version__ = "3.5.4"
 
     def __init__(self, bot: Red):
         self.bot = bot

--- a/adventure/charsheet.py
+++ b/adventure/charsheet.py
@@ -1511,7 +1511,7 @@ class Character:
             tresure[0] += max(int(self.rebirths), 0)
 
         self.weekly_score.update({"rebirths": self.weekly_score.get("rebirths", 0) + 1})
-        self.heroclass["cooldown"] = time.time() + 60 # Set skill cooldown to 60s from rebirth
+        self.heroclass["cooldown"] = time.time() + 60  # Set skill cooldown to 60s from rebirth
         return {
             "adventures": self.adventures,
             "nega": self.nega,

--- a/adventure/charsheet.py
+++ b/adventure/charsheet.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import logging
 import random
+import time
 from copy import copy
 from datetime import date, datetime, timedelta
 from typing import Any, Dict, List, MutableMapping, Optional, Tuple
@@ -1510,7 +1511,7 @@ class Character:
             tresure[0] += max(int(self.rebirths), 0)
 
         self.weekly_score.update({"rebirths": self.weekly_score.get("rebirths", 0) + 1})
-
+        self.heroclass["cooldown"] = time.time() + 60 # Set skill cooldown to 60s from rebirth
         return {
             "adventures": self.adventures,
             "nega": self.nega,

--- a/adventure/class_abilities.py
+++ b/adventure/class_abilities.py
@@ -678,6 +678,22 @@ class ClassAbilities(AdventureMixin):
                         cdef = session.monster_modified_stats.get("cdef", 1.0)
                         hp = session.monster_modified_stats["hp"]
                         diplo = session.monster_modified_stats["dipl"]
+                        choice = random.choice(["physical", "magic", "diplomacy"])
+                        if choice == "physical":
+                            physical_roll = 0.4
+                            magic_roll = 0.6
+                            diplo_roll = 0.8
+                        elif choice == "magic":
+                            physical_roll = 0.8
+                            magic_roll = 0.4
+                            diplo_roll = 0.6
+                        else:
+                            physical_roll = 0.8
+                            magic_roll = 0.6
+                            diplo_roll = 0.4
+
+
+
                         if roll == 1:
                             hp = int(hp * self.ATTRIBS[session.attribute][0] * session.monster_stats)
                             dipl = int(diplo * self.ATTRIBS[session.attribute][1] * session.monster_stats)
@@ -729,7 +745,9 @@ class ClassAbilities(AdventureMixin):
                                 challenge=session.challenge,
                             )
                             self._sessions[ctx.guild.id].exposed = True
-                        if roll >= 0.4:
+
+
+                        if roll >= physical_roll:
                             if pdef >= 1.5:
                                 msg += _("Swords bounce off this monster as it's skin is **almost impenetrable!**\n")
                             elif pdef >= 1.25:
@@ -740,7 +758,7 @@ class ClassAbilities(AdventureMixin):
                                 msg += _("This monster is **soft and easy** to slice!\n")
                             else:
                                 msg += _("Swords slice through this monster like a **hot knife through butter!**\n")
-                        if roll >= 0.6:
+                        if roll >= magic_roll:
                             if mdef >= 1.5:
                                 msg += _("Magic? Pfft, magic is **no match** for this creature!\n")
                             elif mdef >= 1.25:
@@ -751,7 +769,7 @@ class ClassAbilities(AdventureMixin):
                                 msg += _("This monster's hide **melts to magic!**\n")
                             else:
                                 msg += _("Magic spells are **hugely effective** against this monster!\n")
-                        if roll >= 0.8:
+                        if roll >= diplo_roll:
                             if cdef >= 1.5:
                                 msg += _(
                                     "You think you are charismatic? Pfft, this creature **couldn't care less** for what you want to say!\n"

--- a/adventure/class_abilities.py
+++ b/adventure/class_abilities.py
@@ -692,8 +692,6 @@ class ClassAbilities(AdventureMixin):
                             magic_roll = 0.6
                             diplo_roll = 0.4
 
-
-
                         if roll == 1:
                             hp = int(hp * self.ATTRIBS[session.attribute][0] * session.monster_stats)
                             dipl = int(diplo * self.ATTRIBS[session.attribute][1] * session.monster_stats)
@@ -745,7 +743,6 @@ class ClassAbilities(AdventureMixin):
                                 challenge=session.challenge,
                             )
                             self._sessions[ctx.guild.id].exposed = True
-
 
                         if roll >= physical_roll:
                             if pdef >= 1.5:

--- a/adventure/class_abilities.py
+++ b/adventure/class_abilities.py
@@ -1184,8 +1184,8 @@ class ClassAbilities(AdventureMixin):
         base_att = max(character._att, 1)
         modifier_bonus_luck = 0.01 * base_luck // 10
         modifier_bonus_int = 0.01 * base_int // 20
-        modifier_penalty_str = -0.01 * base_att // 20
-        modifier_penalty_cha = -0.01 * base_cha // 10
+        modifier_penalty_str = 0.01 * base_att // 20
+        modifier_penalty_cha = 0.01 * base_cha // 20
         modifier = sum([modifier_bonus_int, modifier_bonus_luck, modifier_penalty_cha, modifier_penalty_str, modifier])
         modifier = max(0.001, modifier)
 

--- a/adventure/class_abilities.py
+++ b/adventure/class_abilities.py
@@ -281,7 +281,7 @@ class ClassAbilities(AdventureMixin):
                                 await class_msg.edit(
                                     content=box(
                                         _("{}, you will remain a {}").format(
-                                            escape(ctx.author.display_name, c.heroclass["name"])
+                                            escape(ctx.author.display_name), c.heroclass["name"]
                                         ),
                                         lang="css",
                                     )

--- a/adventure/class_abilities.py
+++ b/adventure/class_abilities.py
@@ -767,7 +767,7 @@ class ClassAbilities(AdventureMixin):
 
                     if msg:
                         image = None
-                        if roll >= 0.4:
+                        if roll >= 0.4 and not session.no_monster:
                             image = session.monster["image"]
                         return await smart_embed(ctx, msg, image=image)
                     else:


### PR DESCRIPTION
closes #391 - Properly hide Transcended in hardmode, always show on easy mode
closes #389 - Fixes incorrect usage of `escape`
closes #386 - Dont try to add image to monsterless adventures
closes #384 - Tinker buff
closes #377 - add a 60s cooldown to skills after rebirth
closes #365 - Randomise resistance info
closes #376 - Set monster mininum stats to 1