### PR TITLE
Set balance to 0 if one can't be retrieved (running `[p]stat` in dm in certain situations (non global bank)

### DIFF
--- a/adventure/charsheet.py
+++ b/adventure/charsheet.py
@@ -1299,7 +1299,10 @@ class Character:
     ):
         """Return a Character object from config and user."""
         data = await config.user(user).all()
-        balance = await bank.get_balance(user)
+        try:
+            balance = await bank.get_balance(user)
+        except Exception:
+            balance = 0
         equipment = {k: Item.from_json(ctx, v) if v else None for k, v in data["items"].items() if k != "backpack"}
         if "int" not in data["skill"]:
             data["skill"]["int"] = 0


### PR DESCRIPTION

closes #364

Note:
In hindsight https://github.com/aikaterna/gobcog/pull/407 will also depend on this fix as #364 will become a lot regular when #407 is merged if this fix is not applied