### PR TITLE
Improve SP calculation

### DIFF
--- a/adventure/adventure.py
+++ b/adventure/adventure.py
@@ -93,7 +93,7 @@ class Adventure(
             user_id
         ).clear()  # This will only ever touch the separate currency, leaving bot economy to be handled by core.
 
-    __version__ = "3.5.7"
+    __version__ = "3.5.8"
 
     def __init__(self, bot: Red):
         self.bot = bot

--- a/adventure/charsheet.py
+++ b/adventure/charsheet.py
@@ -1570,17 +1570,14 @@ class Character:
 
 
 async def calculate_sp(lvl_end: int, c: Character):
-    points = c.rebirths * 10
-    async for _loop_counter in AsyncIter(range(lvl_end), steps=100):
-        if lvl_end >= 300:
-            points += 1
-        elif lvl_end >= 200:
-            points += 5
-        elif lvl_end >= 100:
-            points += 1
-        elif lvl_end >= 0:
-            points += 0.5
-        lvl_end -= 1
+    points_300 = lvl_end - 300 if lvl_end >= 300 else 0
+    points_200 = (lvl_end - 200) - points_300 if lvl_end >= 200 else 0
+    points_100 = (lvl_end - 100) - points_300 - points_200 if lvl_end >= 100 else 0
+    points_0 = lvl_end - points_100 - points_300 - points_200
+    if 200 <= lvl_end < 300:
+        points_200 += 1
+        points_0 -= 1
+    points = (c.rebirths * 10) + (points_300 * 1) + (points_200 * 5) + (points_100 * 1) + (points_0 * 0.5)
 
     return int(points)
 


### PR DESCRIPTION
This improves the calculation of Skill points so that it's not iterating over a users current level every time it needs to. Testing showed this algorithm is accurate to the existing implementation up to level 12000 and should be for all levels. Testing also showed significantly faster performance in calculating this value which is done every time an adventure is complete and a user has gained a level.