### PR TITLE
Spawn rate adjustments

### DIFF
--- a/adventure/defaults.py
+++ b/adventure/defaults.py
@@ -80,4 +80,6 @@ default_global = {
     "max_allowed_withdraw": 50000,
     "disallow_withdraw": False,
     "easy_mode": False,
+    "reset_by_age": -1,
+    "results_length": 20,
 }


### PR DESCRIPTION
This will be a draft PR adjusting how monster spawns are affected.

The plan is to normalize the spawn rate of ascended creatures. Currently this is calculated by the total damage of the past 20 adventures with some adjustments if the win rate is less than 50%. This leads to a sharp increased chance of ascended monsters spawning once the average group damage exceeds ~250 damage for the past 20 adventures. My initial proposal was to add a limit on how long past adventures can affect that decision. After simulations this idea only temporarily solves the underlying problem given enough time between adventures.

So far this draft only includes the opportunity to adjust how many past adventures are taken into consideration and implements a time-based removal so that given enough time since an adventure it won't be considered in the calculations. There are currently no commands supporting these changes yet as I investigate a more thorough solution. I feel like these will still be fundamental in allowing some control over these spawn changes.