### PR TITLE
More fixes for slot changes

### DIFF
--- a/adventure/adventure.py
+++ b/adventure/adventure.py
@@ -93,7 +93,7 @@ class Adventure(
             user_id
         ).clear()  # This will only ever touch the separate currency, leaving bot economy to be handled by core.
 
-    __version__ = "4.0.3"
+    __version__ = "4.0.4"
 
     def __init__(self, bot: Red):
         self.bot = bot

--- a/adventure/loot.py
+++ b/adventure/loot.py
@@ -365,7 +365,7 @@ class LootCommands(AdventureMixin):
             )
             return None
         slot = item.slot
-        old_item = getattr(character, item.slot.name, None)
+        old_item = getattr(character, item.slot.char_slot, None)
         old_stats = ""
 
         if old_item:
@@ -520,7 +520,7 @@ class LootCommands(AdventureMixin):
                     f"{bold(ctx.author.display_name)}, you need to be level "
                     f"`{equiplevel}` to equip this item. I've put it in your backpack.",
                 )
-            if not getattr(character, item.slot.name):
+            if not getattr(character, item.slot.char_slot):
                 equip_msg = box(
                     _("{user} equipped {item} ({slot} slot).").format(
                         user=escape(ctx.author.display_name), item=item, slot=slot
@@ -533,7 +533,7 @@ class LootCommands(AdventureMixin):
                         user=escape(ctx.author.display_name),
                         item=item,
                         slot=slot,
-                        old_item=getattr(character, item.slot.name),
+                        old_item=getattr(character, item.slot.char_slot),
                     ),
                     lang="ansi",
                 )


### PR DESCRIPTION
Fix an error in `[p]loot` when the user tries to equip a 2h weapon or previously had a 2h weapon equipped.