### PR TITLE
Fix [p]negaverse stealing items of norma, rare, epic, event and forged rarity

### DIFF
--- a/adventure/charsheet.py
+++ b/adventure/charsheet.py
@@ -731,7 +731,7 @@ class Character:
     async def looted(self, how_many: int = 1, exclude: set = None) -> List[Tuple[str, int]]:
         if exclude is None:
             exclude = {Rarities.normal, Rarities.rare, Rarities.epic, Rarities.forged}
-        exclude.add("forged")
+        exclude.add(Rarities.forged)
         items = [i for n, i in self.backpack.items() if i.rarity not in exclude]
         looted_so_far = 0
         looted = []

--- a/adventure/negaverse.py
+++ b/adventure/negaverse.py
@@ -14,7 +14,7 @@ from redbot.core.utils.chat_formatting import bold, box, humanize_number
 from .abc import AdventureMixin
 from .bank import bank
 from .charsheet import Character
-from .constants import Treasure
+from .constants import Rarities,Treasure
 from .helpers import ConfirmView, escape, is_dev, smart_embed
 
 _ = Translator("Adventure", __file__)
@@ -178,7 +178,7 @@ class Negaverse(AdventureMixin):
                 loss_string = _("all of their")
                 loss_state = True
                 items = await character.looted(
-                    how_many=max(int(10 - roll) // 2, 1), exclude={"event", "normal", "rare", "epic"}
+                    how_many=max(int(10 - roll) // 2, 1), exclude={Rarities.event, Rarities.normal, Rarities.rare, Rarities.epic}
                 )
                 if items:
                     item_string = "\n".join([f"{v} x{i}" for v, i in items])
@@ -216,7 +216,7 @@ class Negaverse(AdventureMixin):
                 loss_state = True
                 if character.bal < loss:
                     items = await character.looted(
-                        how_many=max(int(10 - roll) // 2, 1), exclude={"event", "normal", "rare", "epic"}
+                        how_many=max(int(10 - roll) // 2, 1), exclude={Rarities.event, Rarities.normal, Rarities.rare, Rarities.epic}
                     )
                     if items:
                         item_string = "\n".join([f"{v} {i}" for v, i in items])
@@ -316,7 +316,7 @@ class Negaverse(AdventureMixin):
                 loss_state = True
                 if character.bal < loss:
                     items = await character.looted(
-                        how_many=max(int(10 - roll) // 2, 1), exclude={"event", "normal", "rare", "epic"}
+                        how_many=max(int(10 - roll) // 2, 1), exclude={Rarities.event, Rarities.normal, Rarities.rare, Rarities.epic}
                     )
                     if items:
                         item_string = "\n".join([f"{i}  - {v}" for v, i in items])


### PR DESCRIPTION
https://github.com/aikaterna/gobcog/commit/9be13fab25e225b6bc0e3313e362aee6a2a166e6 introduced the Rarity class but forgot to update the references in [p]negaverse. This caused items of excluded rarities to be included (and stolen) anyway, as described in https://github.com/aikaterna/gobcog/issues/449

Some screenshots:
Backpack with different rarities, including 1 legendary item
![image](https://github.com/aikaterna/gobcog/assets/1153754/f5167267-4414-4b40-9ac3-e33e06a4697f)

[p]negaverse stealing the legendary item, as expected
![image](https://github.com/aikaterna/gobcog/assets/1153754/b9513a94-ee35-4779-afac-98fbbbb0d494)

at the next iteration, not items are stolen as there are only normal/rare/epic
![image](https://github.com/aikaterna/gobcog/assets/1153754/5ef16826-2197-4a03-85be-23d4b5a0d275)
