### PR TITLE
Fix cooldown timer showing wrong time with Special Action button

### DIFF
--- a/adventure/game_session.py
+++ b/adventure/game_session.py
@@ -288,7 +288,7 @@ class SpecialActionButton(discord.ui.Button):
         self.label_name = "Special Action"
 
     async def send_cooldown(self, interaction: discord.Interaction, c: Character, cooldown_time: int):
-        cooldown_time = int((c.heroclass["cooldown"]) + cooldown_time)
+        cooldown_time = int((c.heroclass["cooldown"]))
         msg = _(
             "Your hero is currently recovering from the last time "
             "they used this skill or they have just changed their heroclass. "


### PR DESCRIPTION
The cooldown shown when clicking on "Special Action" button was double the time.

Before this PR:
![image](https://github.com/aikaterna/gobcog/assets/1153754/ef906a53-c0ca-4eee-a030-f1d089559cbb)

After this PR:
![image](https://github.com/aikaterna/gobcog/assets/1153754/1ed8de54-dd04-445f-841c-938b700afc68)
