### PR TITLE
Update dispatching system

### DIFF
--- a/adventure/abc.py
+++ b/adventure/abc.py
@@ -10,6 +10,7 @@ from redbot.core import Config, commands
 from redbot.core.bot import Red
 
 if TYPE_CHECKING:
+    from .adventureresult import AdventureResults
     from .adventureset import TaxesConverter
     from .charsheet import Character, Item
     from .constants import Rarities, Treasure
@@ -42,6 +43,7 @@ class AdventureMixin(ABC):
     def __init__(self, *_args):
         self.config: Config
         self.bot: Red
+        self._adv_results: AdventureResults
         self.settings: Dict[Any, Any]
         self.emojis: SimpleNamespace
         self._ready: asyncio.Event
@@ -148,6 +150,10 @@ class AdventureMixin(ABC):
 
     @abstractmethod
     async def _simple(self, ctx: commands.Context, adventure_msg, challenge: str = None, attribute: str = None):
+        raise NotImplementedError()
+
+    @abstractmethod
+    def dispatch_adventure(self, session: GameSession, was_exposed: bool = False):
         raise NotImplementedError()
 
     @abstractmethod

--- a/adventure/class_abilities.py
+++ b/adventure/class_abilities.py
@@ -580,8 +580,10 @@ class ClassAbilities(AdventureMixin):
                                 skill=self.emojis.skills.psychic,
                             ),
                         )
+                session = self._sessions[ctx.guild.id]
+                was_exposed = not session.exposed
                 if good:
-                    session = self._sessions[ctx.guild.id]
+
                     if roll <= 0.4:
                         return await smart_embed(ctx, _("You suck."))
                     msg = ""
@@ -700,7 +702,10 @@ class ClassAbilities(AdventureMixin):
                         image = None
                         if roll >= 0.4 and not session.no_monster:
                             image = session.monster["image"]
-                        return await smart_embed(ctx, msg, image=image)
+                        response_msg = await smart_embed(ctx, msg, image=image)
+                        if session.exposed and not session.easy_mode:
+                            self.dispatch_adventure(session, was_exposed=was_exposed)
+                        return response_msg
                     else:
                         return await smart_embed(ctx, _("You have failed to discover anything about this monster."))
             else:

--- a/adventure/dev.py
+++ b/adventure/dev.py
@@ -212,7 +212,12 @@ class DevCommands(AdventureMixin):
                     f"(hp:{hp}-char:{dipl}-pdef:{pdef}-mdef:{mdef}-cdef:{cdef})\n\n"
                 )
         else:
-            msg += "None."
+            msg += "None.\n\n"
+        msg += bold(_("Guild Stats\n"))
+        stats = self._adv_results.get_stat_range(ctx)
+        msg += _("Main Stat: {stat_type}\nMin Stat: {min_stat}\nMax Stat: {max_stat}\nWin%: {win_percent}").format(
+            stat_type=stats.stat_type, min_stat=stats.min_stat, max_stat=stats.max_stat, win_percent=stats.win_percent
+        )
         for page in pagify(msg, delims=["\n\n"], page_length=1000):
             embed = discord.Embed(description=page)
             embed_list.append(embed)


### PR DESCRIPTION
- Bump to version 4.1.1
- Now all dispatches happen after the session has started.
- Dispatches provide the whole game session if more information is needed.
- Provides some but not all backwards compatibility since it's a game session being sent now not a context object.
 - A send message was added to the session object so it can be used that way.
 - The session channel was added to the session object so it's closer to a context object.
 - If context specifics are required they're already on the session via `session.ctx`.
- When a psychic reveals a special attribute about the monster it will now dispatch that event as if the adventure had started. No need to ping people when you find out it was transcended after, the bot will do it for you.
- Attach the adventure cog to the dev environment for devs in the dev list.
- Include the current server stats in `[p]adventurestats`.
 - These stats are used in filtering what monsters are available.