### PR TITLE
Fix an issue where cbackpack was not able to find set items.

### DIFF
--- a/adventure/class_abilities.py
+++ b/adventure/class_abilities.py
@@ -59,7 +59,7 @@ class ClassAbilities(AdventureMixin):
                     "So you feel like taking on a class, {author}?\n"
                     "Available classes are: {classes}\n"
                     "Use `{prefix}heroclass name-of-class` to choose one."
-                ).format(author=bold(ctx.author.display_name), classes=classes, prefix=ctx.prefix),
+                ).format(author=bold(ctx.author.display_name), classes=classes, prefix=ctx.clean_prefix),
             )
 
         else:
@@ -281,7 +281,7 @@ class ClassAbilities(AdventureMixin):
                     return await ctx.send(
                         box(
                             _("{author}, you already have a pet. Try foraging ({prefix}pet forage).").format(
-                                author=escape(ctx.author.display_name), prefix=ctx.prefix
+                                author=escape(ctx.author.display_name), prefix=ctx.clean_prefix
                             ),
                             lang="ansi",
                         )

--- a/adventure/converters.py
+++ b/adventure/converters.py
@@ -851,7 +851,7 @@ class BackpackFilterParser(commands.Converter):
         else:
             command = ""
         response = {}
-        set_names = set(SET_BONUSES.keys())
+        set_names = set(ctx.cog.SET_BONUSES.keys())
         parser = NoExitParser(description="Backpack Filter Parsing.", add_help=False)
         parser.add_argument("--str", dest="strength", nargs="+")
         parser.add_argument("--strength", dest="strength", nargs="+")

--- a/adventure/economy.py
+++ b/adventure/economy.py
@@ -418,7 +418,7 @@ class EconomyCommands(AdventureMixin):
                 ctx,
                 box(
                     ("Valid loot types: {loot_types}: " "ex. `{prefix}give loot normal @locastan` ").format(
-                        prefix=ctx.prefix, loot_types=humanize_list([i.ansi for i in loot_types])
+                        prefix=ctx.clean_prefix, loot_types=humanize_list([i.ansi for i in loot_types])
                     ),
                     lang="ansi",
                 ),


### PR DESCRIPTION
Prefer ctx.clean_prefix instead of just ctx.prefix.