### PR TITLE
4.1.2 Fix rebirth costs requiring a higher upfront cost

### DIFF
--- a/adventure/adventure.py
+++ b/adventure/adventure.py
@@ -94,7 +94,7 @@ class Adventure(
             user_id
         ).clear()  # This will only ever touch the separate currency, leaving bot economy to be handled by core.
 
-    __version__ = "4.1.1"
+    __version__ = "4.1.2"
 
     def __init__(self, bot: Red):
         self.bot = bot

--- a/adventure/charsheet.py
+++ b/adventure/charsheet.py
@@ -1009,6 +1009,7 @@ class Character:
                 item = backpack[item_name]
                 item_slots = item.slot
                 slot_name = item_slots.get_name()
+                mult = 2 if item.slot is Slot.two_handed else 1
                 if rarity_exclude is not None and item.rarity.name in rarity_exclude:
                     continue
 
@@ -1045,39 +1046,40 @@ class Character:
                         continue
                 if level:
                     if (d := level.get("equal")) is not None:
-                        if e_level != d:
+                        if item.lvl != d:
                             continue
-                    elif not level["min"] < e_level < level["max"]:
+                    elif not level["min"] < item.lvl < level["max"]:
                         continue
                 if dexterity:
                     if (d := dexterity.get("equal")) is not None:
-                        if item.dex != d:
+                        if item.dex*mult != d:
                             continue
-                    elif not dexterity["min"] < item.dex < dexterity["max"]:
+                    elif not dexterity["min"] < item.dex*mult < dexterity["max"]:
                         continue
                 if luck:
                     if (d := luck.get("equal")) is not None:
-                        if item.luck != d:
+                        if item.luck*mult != d:
                             continue
-                    elif not luck["min"] < item.luck < luck["max"]:
+                    elif not luck["min"] < item.luck*mult < luck["max"]:
                         continue
                 if charisma:
                     if (d := charisma.get("equal")) is not None:
-                        if item.cha != d:
+                        if item.cha*mult != d:
                             continue
-                    elif not charisma["min"] < item.cha < charisma["max"]:
+                    elif not charisma["min"] < item.cha*mult < charisma["max"]:
                         continue
                 if intelligence:
                     if (d := intelligence.get("equal")) is not None:
-                        if item.int != d:
+                        if item.int*mult != d:
                             continue
-                    elif not intelligence["min"] < item.int < intelligence["max"]:
+                    elif not intelligence["min"] < item.int*mult < intelligence["max"]:
                         continue
                 if strength:
+
                     if (d := strength.get("equal")) is not None:
-                        if item.att != d:
+                        if item.att*mult != d:
                             continue
-                    elif not strength["min"] < item.att <= strength["max"]:
+                    elif not strength["min"] < item.att*mult <= strength["max"]:
                         continue
 
                 if slot_name not in tmp:
@@ -1090,6 +1092,7 @@ class Character:
                 item = backpack[item_name]
                 item_slots = item.slot
                 slot_name = item_slots.get_name()
+                mult = 2 if item.slot is Slot.two_handed else 1
                 if rarity_exclude is not None and item.rarity in rarity_exclude:
                     continue
 
@@ -1124,39 +1127,39 @@ class Character:
                         continue
                 if level:
                     if (d := level.get("equal")) is not None:
-                        if e_level == d:
+                        if item.lvl == d:
                             continue
-                    elif level["min"] < e_level < level["max"]:
+                    elif level["min"] < item.lvl < level["max"]:
                         continue
                 if dexterity:
                     if (d := dexterity.get("equal")) is not None:
-                        if item.dex == d:
+                        if item.dex*mult == d:
                             continue
-                    elif dexterity["min"] < item.dex < dexterity["max"]:
+                    elif dexterity["min"] < item.dex*mult < dexterity["max"]:
                         continue
                 if luck:
                     if (d := luck.get("equal")) is not None:
-                        if item.luck == d:
+                        if item.luck*mult == d:
                             continue
-                    elif luck["min"] < item.luck < luck["max"]:
+                    elif luck["min"] < item.luck*mult < luck["max"]:
                         continue
                 if charisma:
                     if (d := charisma.get("equal")) is not None:
-                        if item.cha == d:
+                        if item.cha*mult == d:
                             continue
-                    elif charisma["min"] < item.cha < charisma["max"]:
+                    elif charisma["min"] < item.cha*mult < charisma["max"]:
                         continue
                 if intelligence:
                     if (d := intelligence.get("equal")) is not None:
-                        if item.int == d:
+                        if item.int*mult == d:
                             continue
-                    elif intelligence["min"] < item.int < intelligence["max"]:
+                    elif intelligence["min"] < item.int*mult < intelligence["max"]:
                         continue
                 if strength:
                     if (d := strength.get("equal")) is not None:
-                        if item.att == d:
+                        if item.att*mult == d:
                             continue
-                    elif strength["min"] < item.att <= strength["max"]:
+                    elif strength["min"] < item.att*mult <= strength["max"]:
                         continue
                 if slot_name not in tmp:
                     tmp[slot_name] = []

--- a/adventure/charsheet.py
+++ b/adventure/charsheet.py
@@ -1052,34 +1052,33 @@ class Character:
                         continue
                 if dexterity:
                     if (d := dexterity.get("equal")) is not None:
-                        if item.dex*mult != d:
+                        if item.dex * mult != d:
                             continue
-                    elif not dexterity["min"] < item.dex*mult < dexterity["max"]:
+                    elif not dexterity["min"] < item.dex * mult < dexterity["max"]:
                         continue
                 if luck:
                     if (d := luck.get("equal")) is not None:
-                        if item.luck*mult != d:
+                        if item.luck * mult != d:
                             continue
-                    elif not luck["min"] < item.luck*mult < luck["max"]:
+                    elif not luck["min"] < item.luck * mult < luck["max"]:
                         continue
                 if charisma:
                     if (d := charisma.get("equal")) is not None:
-                        if item.cha*mult != d:
+                        if item.cha * mult != d:
                             continue
-                    elif not charisma["min"] < item.cha*mult < charisma["max"]:
+                    elif not charisma["min"] < item.cha * mult < charisma["max"]:
                         continue
                 if intelligence:
                     if (d := intelligence.get("equal")) is not None:
-                        if item.int*mult != d:
+                        if item.int * mult != d:
                             continue
-                    elif not intelligence["min"] < item.int*mult < intelligence["max"]:
+                    elif not intelligence["min"] < item.int * mult < intelligence["max"]:
                         continue
                 if strength:
-
                     if (d := strength.get("equal")) is not None:
-                        if item.att*mult != d:
+                        if item.att * mult != d:
                             continue
-                    elif not strength["min"] < item.att*mult <= strength["max"]:
+                    elif not strength["min"] < item.att * mult <= strength["max"]:
                         continue
 
                 if slot_name not in tmp:
@@ -1133,33 +1132,33 @@ class Character:
                         continue
                 if dexterity:
                     if (d := dexterity.get("equal")) is not None:
-                        if item.dex*mult == d:
+                        if item.dex * mult == d:
                             continue
-                    elif dexterity["min"] < item.dex*mult < dexterity["max"]:
+                    elif dexterity["min"] < item.dex * mult < dexterity["max"]:
                         continue
                 if luck:
                     if (d := luck.get("equal")) is not None:
-                        if item.luck*mult == d:
+                        if item.luck * mult == d:
                             continue
-                    elif luck["min"] < item.luck*mult < luck["max"]:
+                    elif luck["min"] < item.luck * mult < luck["max"]:
                         continue
                 if charisma:
                     if (d := charisma.get("equal")) is not None:
-                        if item.cha*mult == d:
+                        if item.cha * mult == d:
                             continue
-                    elif charisma["min"] < item.cha*mult < charisma["max"]:
+                    elif charisma["min"] < item.cha * mult < charisma["max"]:
                         continue
                 if intelligence:
                     if (d := intelligence.get("equal")) is not None:
-                        if item.int*mult == d:
+                        if item.int * mult == d:
                             continue
-                    elif intelligence["min"] < item.int*mult < intelligence["max"]:
+                    elif intelligence["min"] < item.int * mult < intelligence["max"]:
                         continue
                 if strength:
                     if (d := strength.get("equal")) is not None:
-                        if item.att*mult == d:
+                        if item.att * mult == d:
                             continue
-                    elif strength["min"] < item.att*mult <= strength["max"]:
+                    elif strength["min"] < item.att * mult <= strength["max"]:
                         continue
                 if slot_name not in tmp:
                     tmp[slot_name] = []

--- a/adventure/converters.py
+++ b/adventure/converters.py
@@ -855,6 +855,8 @@ class BackpackFilterParser(commands.Converter):
         parser = NoExitParser(description="Backpack Filter Parsing.", add_help=False)
         parser.add_argument("--str", dest="strength", nargs="+")
         parser.add_argument("--strength", dest="strength", nargs="+")
+        parser.add_argument("--att", dest="strength", nargs="+")
+        parser.add_argument("--attack", dest="strength", nargs="+")
 
         parser.add_argument("--intelligence", dest="intelligence", nargs="+")
         parser.add_argument("--int", dest="intelligence", nargs="+")

--- a/adventure/rebirth.py
+++ b/adventure/rebirth.py
@@ -43,9 +43,14 @@ class RebirthCommands(AdventureMixin):
                 rebirth_cost = await self.config.guild(ctx.guild).rebirth_cost()
             else:
                 rebirth_cost = await self.config.rebirth_cost()
-            rebirthcost = 1000 * c.rebirths
+            base_cost = 1000 * c.rebirths
             current_balance = c.bal
             last_known_currency = c.last_known_currency
+            bal = await bank.get_balance(ctx.author)
+            withdraw = max(base_cost, int(max((bal - base_cost), 1) * (rebirth_cost / 100.0)))
+            currency_name = await bank.get_currency_name(
+                    ctx.guild,
+                )
             if last_known_currency and current_balance / last_known_currency < 0.25:
                 currency_name = await bank.get_currency_name(
                     ctx.guild,
@@ -61,14 +66,15 @@ class RebirthCommands(AdventureMixin):
                     ),
                 )
             else:
-                has_fund = await has_funds(ctx.author, rebirthcost)
+                has_fund = await has_funds(ctx.author, withdraw)
             if not has_fund:
-                currency_name = await bank.get_currency_name(
-                    ctx.guild,
-                )
+
+                remaining = withdraw - current_balance
                 return await smart_embed(
                     ctx,
-                    _("You need more {currency_name} to be able to rebirth.").format(currency_name=currency_name),
+                    _("You need {remaining} more {currency_name} to be able to rebirth.").format(
+                        currency_name=currency_name, remaining=humanize_number(remaining)
+                    ),
                 )
             space = "\N{EN SPACE}"
             view = ConfirmView(60, ctx.author)
@@ -76,7 +82,7 @@ class RebirthCommands(AdventureMixin):
                 ctx,
                 _(
                     "Rebirthing will:\n\n"
-                    "* cost {cost}% of your credits\n"
+                    "* cost {cost} of your {currency}\n"
                     "* cost all of your current gear\n"
                     "{space}- Legendary and Ascended items lose one degradation "
                     "point per rebirth and are broken down when they have 0 left.\n"
@@ -86,12 +92,13 @@ class RebirthCommands(AdventureMixin):
                     "for acquiring more powerful items, a higher max level, and the "
                     "ability to convert chests to higher rarities after the second rebirth.\n\n"
                     "Would you like to rebirth?"
-                ).format(cost=int(rebirth_cost), space=space * 4),
+                ).format(cost=humanize_number(withdraw), space=space * 4, currency=currency_name),
                 view=view,
             )
             await view.wait()
 
             if view.confirmed is None:
+                await open_msg.edit(view=None)
                 await smart_embed(ctx, "I can't wait forever, you know.")
                 return
             if not view.confirmed:
@@ -120,12 +127,9 @@ class RebirthCommands(AdventureMixin):
                     view=None,
                 )
                 return
-            bal = await bank.get_balance(ctx.author)
-            if bal >= 1000:
-                withdraw = int((bal - 1000) * (rebirth_cost / 100.0))
+            if bal >= withdraw:
                 await bank.withdraw_credits(ctx.author, withdraw)
             else:
-                withdraw = int(bal * (rebirth_cost / 100.0))
                 await bank.set_balance(ctx.author, 0)
 
             await open_msg.edit(

--- a/adventure/rebirth.py
+++ b/adventure/rebirth.py
@@ -49,8 +49,8 @@ class RebirthCommands(AdventureMixin):
             bal = await bank.get_balance(ctx.author)
             withdraw = max(base_cost, int(max((bal - base_cost), 1) * (rebirth_cost / 100.0)))
             currency_name = await bank.get_currency_name(
-                    ctx.guild,
-                )
+                ctx.guild,
+            )
             if last_known_currency and current_balance / last_known_currency < 0.25:
                 currency_name = await bank.get_currency_name(
                     ctx.guild,


### PR DESCRIPTION
- Rebirth cost now has a fixed price of 1000*rebirths in addition to a percentage of the users balance if set.
- Add `--att` and `--attack` aliases for cbackpack.
- Fix cbackpack incorrectly filtering based on certain criteria.
  - Two handed weapons were not filtered based on their actual stat ranges
  - lvl filter was showing equip level not item level.